### PR TITLE
Fix compilation on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONFIG_CXX_ALLOCATOR := true
 
 CPPFLAGS := -D_GNU_SOURCE
-SHARED_FLAGS := -O2 -flto -fPIC -fvisibility=hidden -fno-plt -pipe -Wall -Wextra
+SHARED_FLAGS := -O2 -flto -fPIC -fvisibility=hidden -fno-plt -pipe -Wall -Wextra -pthread
 CFLAGS := -std=c11 $(SHARED_FLAGS) -Wmissing-prototypes
 CXXFLAGS := -std=c++14 $(SHARED_FLAGS)
 LDFLAGS := -Wl,-z,defs,-z,relro,-z,now,-z,nodlopen,-z,text


### PR DESCRIPTION
Without explicitly specifying `-pthread`, the compilation fails on Ubuntu:

```
cc -std=c11 -O2 -flto -fPIC -fvisibility=hidden -fno-plt -pipe -Wall -Wextra -Wmissing-prototypes -Wl,-z,defs,-z,relro,-z,now,-z,nodlopen,-z,text -shared chacha.o malloc.o memory.o pages.o random.o util.o new.o -lstdc++ -o hardened_malloc.so
/tmp/ccNSnzLn.ltrans0.ltrans.o: In function `init_slow_path':
<artificial>:(.text.unlikely+0x3f1): undefined reference to `pthread_atfork'
collect2: error: ld returned 1 exit status
Makefile:16: recipe for target 'hardened_malloc.so' failed
make: *** [hardened_malloc.so] Error 1
zsh: exit 2     make
```